### PR TITLE
Mimicking multiple arguments API of node's console

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,10 +14,24 @@ var monkeyPatch = function(name){
 		var origin = traceback()[2];
 		return "("+origin.file + ":" + origin.line + ")"
 	}
+	
+	function sprintf(template, values) {
+		  return template.replace(/%s/g, function() {
+		    return values.shift();
+		  });
+		}
 
 	var that = this;
 	_.each(["log", "info", "warn", "error"], function(severity){
-		that[severity] = function(msg){
+		that[severity] = function(){
+			var args = new Array;
+			for(var o in arguments) {
+				args.push(JSON.stringify(arguments[o]));
+			}
+			var msg = args.shift();
+			if (args.length > 0) {
+				msg = sprintf(msg, args);				
+			}
 			msg = here()+" "+msg;
 			oldConsole[severity](msg)
 			syslog[severity](util.inspect(msg.replace(ansiEscape,'')).replace(apostrophe,""))

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var ain2 = require('ain2')
-var traceback = require('traceback')
+var traceback = require('traceback-safe')
 var _ = require('underscore')
 var util = require('util')
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "ain2": "1.2.x",
-    "traceback": "0.3.x",
+    "traceback": "git+https://github.com/JulianHH/traceback.git"
     "underscore": "1.4.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "ain2": "1.2.x",
-    "traceback": "git+https://github.com/JulianHH/traceback.git"
+    "traceback": "git+https://github.com/JulianHH/traceback.git",
     "underscore": "1.4.x"
   }
 }


### PR DESCRIPTION
Previously, this library allowed only 
`console.log('foo')`

With this PR, you can also do

```
var bar='baz'
console.log('Doing %s with %s', 'foo', bar)
```

or even

```
var foo={ yes: 'no' }
var bar=[1,2,3,4]
console.log('Tried something with %s and %s', foo, bar)
```
